### PR TITLE
Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /config.json
 /temp
 /upload
+__pycache__
+config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the requirements file
+COPY requirements.txt .
+
+# Install Dependencies
+RUN pip3 install -r requirements.txt
+
+# Copy the rest of the application's code
+COPY . .
+
+# Make port 7860 and 9531 available to the world outside this container
+EXPOSE 7860
+EXPOSE 9531
+
+# Run the application when the container launches
+CMD ["sh", "run.sh"]

--- a/config.example.json
+++ b/config.example.json
@@ -10,5 +10,6 @@
   "mode": "webui",
   "api_port": 9531,
   "api_host": "localhost",
-  "webui_port": 7860
+  "webui_port": 7860,
+  "webui_host": "0.0.0.0"
 }

--- a/config.py
+++ b/config.py
@@ -33,3 +33,4 @@ class Config:
             self.api_port = self.config.get('api_port', 9531)
             self.api_host = self.config.get('api_host', 'localhost')
             self.webui_port = self.config.get('webui_port', 7860)
+            self.webui_host = self.config.get('webui_host', '0.0.0.0')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+
+services:
+  chatweb:
+    build: .
+    ports:
+      - "9531:9531"
+      - "7860:7860"
+    volumes:
+      - ./config.json:/app/config.json
+      # - ./:/app
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,8 @@ An improvement was made to generate vectors based on keywords rather than the us
 
 # Getting Started
 
+## Manual installation:
+
 - Install Python3
 - Download this repository by running `git clone https://github.com/SkywalkerDarren/chatWeb.git`
 - Navigate to the directory by running `cd chatWeb`
@@ -34,6 +36,14 @@ An improvement was made to generate vectors based on keywords rather than the us
 - Edit `config.json` and set `open_ai_key` to your OpenAI API key
 - Install dependencies by running `pip3 install -r requirements.txt`
 - Start the application by running `python3 main.py`
+
+## Docker:
+if you prefer, you can also run this project using docker:
+
+- build the container using `docker-compose build` (only needed once when you are not planning to contibute to this repo)
+- copy `config.example.json` to `config.json` and set all the needed stuff. The example config is already fine for running with docker, no need to change anything there, if you don't have the OPEN_AI_KEY in your env variables you can set it here too, or later if you run this app.
+- run the container: `docker-compose up"
+- open the application in browser: `http://localhost:7860`
 
 ## Set language
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,3 +76,4 @@ wsproto
 xxhash
 yarl
 gradio
+psycopg2

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Starting..."
+python3 main.py

--- a/webui.py
+++ b/webui.py
@@ -151,4 +151,4 @@ class Webui:
                 submit_box.click(respond, [msg, chatbot, hash_id_state], [msg, chatbot, dataset_box, kw_box])
                 reset_box.click(reset, None, [init_page, chat_page, chatbot, msg, dataset_box, hash_id_state])
         demo.title = "Chat Web"
-        demo.launch(server_port=self.cfg.webui_port, show_api=False)
+        demo.launch(server_port=self.cfg.webui_port, server_name=self.cfg.webui_host, show_api=False)


### PR DESCRIPTION
This PR adds docker support. The project can be run using docker now. Only the project, no postgres yet.
I also extended webui.py / config.py / cnfig.example.json to be able to use a host name, in my case I was not able to open this project in browser from outside (wsl2) because I needed to allow it publicly (0.0.0.0)