### PR TITLE
fix: guard against empty choices and message=None in LLM response

### DIFF
--- a/ai.py
+++ b/ai.py
@@ -39,6 +39,8 @@ class AI:
             print()
             return data.strip()
         else:
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             print(response.choices[0].message.content.strip())
             input_cost = response.usage.prompt_tokens / 1000 * self._chat_model.input_price_per_k
             output_cost = response.usage.completion_tokens / 1000 * self._chat_model.output_price_per_k


### PR DESCRIPTION
## What

Add a guard in `ai.py` before accessing `response.choices[0].message.content` in the non-streaming branch.

## Why

`client.chat.completions.create()` can return two empty-response shapes:

1. **`choices = []`** — on content-policy rejections, rate-limit errors, or provider failures  
2. **`choices[0].message = None`** — e.g. Gemini 2.5 Flash (via the OpenAI-compatible endpoint) returns HTTP 200 with `finish_reason: PROHIBITED_CONTENT` and `message=None`

Both crash with `IndexError` or `AttributeError`. The guard on line 42 covers both accesses (line 42 and line 48 reuse the same `response` object).

## Change

```python
# Before
print(response.choices[0].message.content.strip())

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
print(response.choices[0].message.content.strip())
```

## Corpus context

Detected by [`pact`](https://github.com/qizwiz/pact) (`llm_response_unguarded` mode), a Z3-verified static analyzer for LLM crash vectors. This pattern was found across 13.7k violations in 786 repos.